### PR TITLE
Add Test Tool and Multi-IP resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+os:
+  - linux
+  - osx
+go:
+  - 1.9
+  - master

--- a/build.bat
+++ b/build.bat
@@ -24,3 +24,4 @@ set GOPATH=%CD%
 echo Compiling to %GOPATH%\bin
 
 go install -v tenta-dns
+go install -v tenta-dns/stresser

--- a/build.sh
+++ b/build.sh
@@ -24,3 +24,4 @@ GOPATH=`pwd`
 echo "Compiling to $GOPATH/bin"
 
 go install -v tenta-dns
+go install -v tenta-dns/stresser

--- a/build.sh
+++ b/build.sh
@@ -23,5 +23,12 @@ GOPATH=`pwd`
 
 echo "Compiling to $GOPATH/bin"
 
-go install -v tenta-dns
-go install -v tenta-dns/stresser
+version="development`date -u +.%Y%m%d.%H%M%S`"
+if [ -n "$BUILD_ID" ]; then
+  version="b${BUILD_ID}"
+fi
+
+echo "Compiling version $version"
+
+go install -ldflags "-X main.version=$version" -v tenta-dns
+go install -ldflags "-X main.version=$version" -v tenta-dns/stresser

--- a/deps.list
+++ b/deps.list
@@ -5,7 +5,7 @@ github.com/gorilla/mux
 github.com/BurntSushi/toml
 github.com/sasha-s/go-hll
 github.com/oschwald/maxminddb-golang
-github.com/dgryski/go-highway
+github.com/tenta-browser/go-highway
 github.com/osrg/gobgp/api
 github.com/sirupsen/logrus
 github.com/mattn/go-colorable

--- a/etc/conf.d/recursor.toml
+++ b/etc/conf.d/recursor.toml
@@ -1,6 +1,6 @@
 servertype="recursor"
 
-opennic=true
+# opennic=true
 
 [domaains]
     [domains.nameinspector]

--- a/src/tenta-dns/common/common.go
+++ b/src/tenta-dns/common/common.go
@@ -25,6 +25,7 @@ package common
 import (
 	"crypto/rand"
 	"math/big"
+	"net"
 	"os"
 	"tenta-dns/log"
 )
@@ -41,4 +42,11 @@ func RandInt(max uint) uint {
 		os.Exit(5)
 	}
 	return uint(bi.Uint64())
+}
+
+func IsPrivateIp(a net.IP) bool {
+	a = a.To4()
+	return a[0] == 10 || // class A private network
+		(a[0] == 172 && a[1] >= 16 && a[1] <= 31) || // class B private networks
+		(a[0] == 192 && a[1] == 168) // class C private networks
 }

--- a/src/tenta-dns/log/log.go
+++ b/src/tenta-dns/log/log.go
@@ -45,7 +45,8 @@ func (l *EventualLogger) Queuef(format string, args ...interface{}) {
 // Flush -- writes out everything from buffer
 func (l *EventualLogger) Flush(target *logrus.Entry) {
 	for _, e := range *l {
-		target.Infof(e)
+		//target.Infof(e)
+		fmt.Printf("%s", e)
 	}
 }
 

--- a/src/tenta-dns/responder/authoritative_dns.go
+++ b/src/tenta-dns/responder/authoritative_dns.go
@@ -38,32 +38,7 @@ func AuthoritativeDNSServer(cfg runtime.AuthorityConfig, rt *runtime.Runtime, v4
 }
 
 func serveAuthoritativeDNS(cfg runtime.AuthorityConfig, rt *runtime.Runtime, v4 bool, net string, d *runtime.ServerDomain) {
-	var ip string
-	if v4 {
-		ip = d.IPv4
-	} else {
-		ip = fmt.Sprintf("[%s]", d.IPv6)
-	}
-	var port int
-	if net == "tcp" {
-		if d.DnsTcpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TCP snitch without a valid TCP port")
-		}
-		port = d.DnsTcpPort
-	} else if net == "udp" {
-		if d.DnsUdpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a UDP snitch without a valid TCP port")
-		}
-		port = d.DnsUdpPort
-	} else if net == "tls" {
-		if d.DnsTlsPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TLS snitch without a valid TLS port")
-		}
-		port = d.DnsTlsPort
-	} else {
-		log.GetLogger("dnsauthority").Warnf("Unknown DNS net type %s", net)
-		return
-	}
+	ip, port := hostInfo(v4, net, d)
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	lg := log.GetLogger("dnsauthority").WithField("host_name", d.HostName).WithField("address", ip).WithField("port", port).WithField("proto", net)
 	notifyStarted := func() {

--- a/src/tenta-dns/responder/net_helpers.go
+++ b/src/tenta-dns/responder/net_helpers.go
@@ -1,0 +1,33 @@
+package responder
+
+import (
+	"tenta-dns/runtime"
+	"fmt"
+)
+
+func hostInfo(v4 bool, net string, d *runtime.ServerDomain) (ip string, port int) {
+	if v4 {
+		ip = d.IPv4
+	} else {
+		ip = fmt.Sprintf("[%s]", d.IPv6)
+	}
+	if net == "tcp" {
+		if d.DnsTcpPort <= runtime.PORT_UNSET {
+			panic("Unable to start a TCP recursive DNS server without a valid TCP port")
+		}
+		port = d.DnsTcpPort
+	} else if net == "udp" {
+		if d.DnsUdpPort <= runtime.PORT_UNSET {
+			panic("Unable to start a UDP recursive DNS server without a valid UDP port")
+		}
+		port = d.DnsUdpPort
+	} else if net == "tls" {
+		if d.DnsTlsPort <= runtime.PORT_UNSET {
+			panic("Unable to start a TLS recursive DNS server without a valid TLS port")
+		}
+		port = d.DnsTlsPort
+	} else {
+		panic(fmt.Sprintf("Unknown network type %s", net))
+	}
+	return
+}

--- a/src/tenta-dns/responder/recursive_data_helpers.go
+++ b/src/tenta-dns/responder/recursive_data_helpers.go
@@ -1,14 +1,16 @@
 package responder
 
 import (
-	"github.com/miekg/dns"
-	"strings"
-	"net/http"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
-	"encoding/xml"
-	"github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
 	"tenta-dns/log"
+	"tenta-dns/runtime"
+
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 // Deep equality check for DS records
@@ -23,7 +25,7 @@ func equalsDS(a, b *dns.DS) bool {
 }
 
 // Download trust anchors
-func getTrustedRootAnchors(l *logrus.Entry, provider string) error {
+func getTrustedRootAnchors(l *logrus.Entry, provider string, ips *runtime.Pool) error {
 	rootDS := make([]dns.RR, 0)
 
 	if provider == "tenta" {
@@ -53,7 +55,7 @@ func getTrustedRootAnchors(l *logrus.Entry, provider string) error {
 		}
 
 	} else if provider == "opennic" {
-		q := newQueryParam(".", dns.TypeDNSKEY, l, new(log.EventualLogger), provider)
+		q := newQueryParam(".", dns.TypeDNSKEY, l, new(log.EventualLogger), provider, ips)
 		krr, e := q.doResolve(resolveMethodFinalQuestion)
 		if e != nil {
 			return fmt.Errorf("Cannot get opennic root keys. [%s]", e.Error())

--- a/src/tenta-dns/responder/recursive_data_helpers.go
+++ b/src/tenta-dns/responder/recursive_data_helpers.go
@@ -1,0 +1,17 @@
+package responder
+
+import (
+	"github.com/miekg/dns"
+	"strings"
+)
+
+// Deep equality check for DS records
+func equalsDS(a, b *dns.DS) bool {
+	if a.Algorithm == b.Algorithm &&
+		strings.ToLower(a.Digest) == strings.ToLower(b.Digest) &&
+		a.DigestType == b.DigestType &&
+		a.KeyTag == b.KeyTag {
+		return true
+	}
+	return false
+}

--- a/src/tenta-dns/responder/recursive_data_helpers.go
+++ b/src/tenta-dns/responder/recursive_data_helpers.go
@@ -3,6 +3,12 @@ package responder
 import (
 	"github.com/miekg/dns"
 	"strings"
+	"net/http"
+	"fmt"
+	"io/ioutil"
+	"encoding/xml"
+	"github.com/sirupsen/logrus"
+	"tenta-dns/log"
 )
 
 // Deep equality check for DS records
@@ -14,4 +20,79 @@ func equalsDS(a, b *dns.DS) bool {
 		return true
 	}
 	return false
+}
+
+// Download trust anchors
+func getTrustedRootAnchors(l *logrus.Entry, provider string) error {
+	rootDS := make([]dns.RR, 0)
+
+	if provider == "tenta" {
+		data, err := http.Get(rootAnchorURL)
+		if err != nil {
+			return fmt.Errorf("Trusted root anchor obtain failed [%s]", err)
+		}
+		defer data.Body.Close()
+		rootCertData, err := ioutil.ReadAll(data.Body)
+		if err != nil {
+			return fmt.Errorf("Cannot read response data [%s]", err)
+		}
+
+		r := resultData{}
+		if err := xml.Unmarshal([]byte(rootCertData), &r); err != nil {
+			return fmt.Errorf("Problem during unmarshal. [%s]", err)
+		}
+
+		for _, dsData := range r.KeyDigest {
+			deleg := new(dns.DS)
+			deleg.Hdr = dns.RR_Header{Name: ".", Rrtype: dns.TypeDS, Class: dns.ClassINET, Ttl: 14400, Rdlength: 0}
+			deleg.Algorithm = dsData.Algorithm
+			deleg.Digest = dsData.Digest
+			deleg.DigestType = dsData.DigestType
+			deleg.KeyTag = dsData.KeyTag
+			rootDS = append(rootDS, deleg)
+		}
+
+	} else if provider == "opennic" {
+		q := newQueryParam(".", dns.TypeDNSKEY, l, new(log.EventualLogger), provider)
+		krr, e := q.doResolve(resolveMethodFinalQuestion)
+		if e != nil {
+			return fmt.Errorf("Cannot get opennic root keys. [%s]", e.Error())
+		}
+		for _, rr := range krr {
+			if k, ok := rr.(*dns.DNSKEY); ok {
+				rootDS = append(rootDS, k.ToDS(2))
+			}
+		}
+	}
+	storeCache(provider, ".", rootDS)
+
+	return nil
+}
+
+// Try to transfer the whole root zone in one shot. That'll speed
+// things up!
+func transferRootZone(l *logrus.Entry, provider string) error {
+	t := new(dns.Transfer)
+	m := new(dns.Msg)
+	m.SetAxfr(".")
+	r, e := t.In(m, rootServers[provider][0].ipv4+":53")
+	if e != nil {
+		return fmt.Errorf("cannot execute zone transfer [%s]", e.Error())
+	}
+
+	for env := range r {
+		if env.Error != nil {
+			l.Infof("Zone transfer envelope error [%s]", env.Error.Error())
+			continue
+		}
+		for _, rr := range env.RR {
+			switch rr.(type) {
+			case *dns.A, *dns.AAAA, *dns.NS:
+				storeCache(provider, rr.Header().Name, []dns.RR{rr})
+			}
+		}
+
+	}
+
+	return nil
 }

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1770,12 +1770,12 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			if err.errorCode != errorUnresolvable && err.errorCode != errorCannotResolve {
 				elogger.Queuef("Failed for [%s -- %d] - [%s]", qp.vanilla, qp.record, err)
 				rt.Stats.Count(StatsQueryFailure)
-				if err.errorCode == errorUnresolvable {
-					response.SetRcode(r, dns.RcodeServerFailure)
-				}
+				response.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
-				response.SetRcode(r, dns.RcodeNameError)
+				if err.errorCode == errorUnresolvable {
+					response.SetRcode(r, dns.RcodeNameError)
+				}
 			}
 			elogger.Flush(l)
 		} else {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -725,7 +725,7 @@ func doTLSDiscovery(target, provider string) (tw time.Duration) {
 func findMatching(ds *dns.DS, dnskeyArr []*dns.DNSKEY) bool {
 	for _, dnskey := range dnskeyArr {
 		//fmt.Printf("cmp:: matching\n%s\n%s\n", dnskey.ToDS(ds.DigestType).String(), ds.String())
-		if compareDS(dnskey.ToDS(ds.DigestType), ds) {
+		if equalsDS(dnskey.ToDS(ds.DigestType), ds) {
 			return true
 		}
 	}
@@ -1677,14 +1677,6 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 	}
 	q.debug("\n\n\nFinishing doResolve for [%s] successfully with [%s]\n\n\n", q.vanilla, q.result)
 	return resultRR, nil
-}
-
-/// helper to compare two DS records (a modified DNSKEY and its parent zone's DS)
-func compareDS(a, b *dns.DS) bool {
-	if a.Algorithm == b.Algorithm && strings.ToLower(a.Digest) == strings.ToLower(b.Digest) && a.DigestType == b.DigestType && a.KeyTag == b.KeyTag {
-		return true
-	}
-	return false
 }
 
 /// TODO -- externalize this call (to a truly side channel), and perhaps supply to the daemon via a config directive

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1764,7 +1764,6 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		answer, err := qp.doResolve(resolveMethodToUse)
 		resolvTime := time.Now().Sub(startTime)
 		response := new(dns.Msg)
-		response.SetRcode(r, dns.RcodeSuccess)
 		if err != nil {
 			elogger.Queuef("RESOLVE RETURNED ERROR [%s]", err.String())
 			if err.errorCode != errorUnresolvable && err.errorCode != errorCannotResolve {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1772,7 +1772,9 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 				response.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
-				response.SetRcode(r, dns.RcodeNameError)
+				if err.errorCode == errorUnresolvable {
+					response.SetRcode(r, dns.RcodeNameError)
+				}
 			}
 			elogger.Flush(l)
 		} else {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1722,7 +1722,8 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			return
 		}
 		/// check with rate limiter (and save to stats on false)
-		if network == "udp" && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
+
+		if network == "udp" && !net.ParseIP(w.RemoteAddr().String()).IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
 			rt.Stats.Tick("resolver", "throttled")
 			rt.Stats.Card(StatsQueryLimitedIps, w.RemoteAddr().String())
 			return

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -689,11 +689,10 @@ func setupDNSClient(client *dns.Client, port *string, target string, tlsCapabili
 		*port = ":53"
 	}
 
-	client.Dialer = &net.Dialer{}
 	if needsTCP {
-		client.Dialer.LocalAddr = ips.RandomizeTCPAddr()
+		client.Dialer = ips.RandomizeTCPDialer()
 	} else {
-		client.Dialer.LocalAddr = ips.RandomizeUDPAddr()
+		client.Dialer = ips.RandomizeUDPDialer()
 	}
 
 	return
@@ -993,7 +992,6 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 	if err == dns.ErrTruncated {
 		q.debug("Retrying on TCP. Stay tuned.\n")
 		setupDNSClient(client, &port, target, serverCapabilityFalse, true, q.provider, q.ips)
-		client.Dialer.LocalAddr = q.ips.RandomizeTCPAddr()
 		reply, rtt, err = client.Exchange(message, target+port)
 	}
 

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -984,6 +984,7 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 
 	//client.Timeout = 5000 * time.Millisecond
 	//client.UDPSize = 4096
+	client.ReadTimeout = 5 * time.Second
 	reply, rtt, err := client.Exchange(message, target+port)
 	q.debug("Question was [%s]\n", message.Question[0].String())
 	q.debug(">>> Query response <<<\n%s\n", reply.String())

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1789,7 +1789,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		}
 
 		// Check with rate limiter (and save to stats on false)
-		if network == "udp" && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
+		if network == "udp" && !w.RemoteAddr().(*net.IPAddr).IP.IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
 			rt.Stats.Tick("resolver", "throttled")
 			rt.Stats.Card(StatsQueryLimitedIps, w.RemoteAddr().String())
 			return

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -989,10 +989,7 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 
 	if err != nil {
 		return nil, t, newError(errorCannotResolve, severityFatal, "simpleResolve failed. [%s]", err)
-	} else if reply.Rcode == dns.RcodeServerFailure {
-		return nil, t, newError(errorCannotResolve, severityNuisance, "simpleResolve got SERVFAIL.")
 	}
-
 	q.debug("Dns rountrip time is [%v]\n", rtt)
 
 	for q.chainOfTrustIntact && subject != dns.TypeDNSKEY {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1764,6 +1764,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		answer, err := qp.doResolve(resolveMethodToUse)
 		resolvTime := time.Now().Sub(startTime)
 		response := new(dns.Msg)
+		response.SetRcode(r, dns.RcodeSuccess)
 		if err != nil {
 			elogger.Queuef("RESOLVE RETURNED ERROR [%s]", err.String())
 			if err.errorCode != errorUnresolvable && err.errorCode != errorCannotResolve {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1773,9 +1773,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 				response.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
-				if err.errorCode == errorUnresolvable {
-					response.SetRcode(r, dns.RcodeNameError)
-				}
+				response.SetRcode(r, dns.RcodeNameError)
 			}
 			elogger.Flush(l)
 		} else {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1693,7 +1693,9 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		rt.Stats.Tick("dns", "queries:recursive")
 		rt.Stats.Card(StatsQueryUniqueIps, w.RemoteAddr().String())
 
-		if strings.Contains(r.Question[0].String(), "vkcache") || r.Question[0].Qtype == dns.TypeANY {
+		// This domain was seen to be polluting the query.
+		// TODO: Configurable fast-drop blacklist
+		if strings.Contains(r.Question[0].String(), "vkcache") {
 			return
 		}
 

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1789,7 +1789,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		}
 
 		// Check with rate limiter (and save to stats on false)
-		if network == "udp" && !w.RemoteAddr().(*net.IPAddr).IP.IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
+		if network == "udp" && !w.RemoteAddr().(*net.UDPAddr).IP.IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
 			rt.Stats.Tick("resolver", "throttled")
 			rt.Stats.Card(StatsQueryLimitedIps, w.RemoteAddr().String())
 			return

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -975,7 +975,7 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 
 	}
 
-	client.Timeout = 5000 * time.Millisecond
+	//client.Timeout = 5000 * time.Millisecond
 	//client.UDPSize = 4096
 	reply, rtt, err := client.Exchange(message, target+port)
 	q.debug(">>> Query response <<<\n%s\n", reply.String())

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -981,8 +981,7 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 	q.debug(">>> Query response <<<\n%s\n", reply.String())
 
 	// if message is larger than generic udp packet size 512, retry on tcp
-	// also, when timed out, or rcode is servfail
-	if err == dns.ErrTruncated || (err != nil && strings.HasSuffix(err.Error(), "timeout")) || reply.Rcode == dns.RcodeServerFailure {
+	if err == dns.ErrTruncated || (err != nil && strings.HasSuffix(err.Error(), "timeout")) {
 		q.debug("Retrying on TCP. Stay tuned.\n")
 		setupDNSClient(client, &port, target, targetCap, true, q.provider)
 		reply, rtt, err = client.Exchange(message, target+port)
@@ -1117,8 +1116,8 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 	/// first of all check the cache
 	/// check fqdn directly for the target recordtype
 	resultRR = make([]dns.RR, 0)
+	q.debug("Trying to resolve directly from cache.\n")
 	rr, tw, err := q.retrieveCache(q.provider, q.vanilla, q.record)
-	fmt.Printf("Trying to resolve directly from cache.[%v][%v]\n", rr, err)
 	q.timeWasted += tw
 	if err == nil {
 		//return rr.(*dns.A).A.String(), nil
@@ -1146,16 +1145,8 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 		}
 		a := rr2[0].(*dns.A)
 		targetServer = a.A.String()
-		for _, nsRR := range rr[1:] {
-			rr2, tw, err = q.retrieveCache(q.provider, nsRR.(*dns.NS).Ns, dns.TypeA)
-			if err != nil {
-				continue
-			}
-			for _, fallbackRR := range rr2 {
-				if _, ok := fallbackRR.(*dns.A); ok {
-					insertFallbackServer(&fallbackServers, fallbackRR)
-				}
-			}
+		if len(rr2) > 1 {
+			populateFallbackServers(&fallbackServers, rr2[1:])
 		}
 		rangelimit = i
 		break

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1289,6 +1289,19 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 
 			foundCNAMEs := make([]*dns.CNAME, 0)
 
+			/// this is a sloppy variant of the return SOA on intermediary queries
+			if len(recordHolder) == 0 && token != q.vanilla {
+				qc := q.newContinationParam(len(q.tokens)-1, oldTargetServer)
+				shortcut, err := qc.doResolve(resolveMethodRecursive)
+				if err != nil {
+					q.debug("Hail Mary failed [%s]\n", err.String())
+				} else {
+					defer qc.join()
+					q.debug("Tried the good old query-more-tokens-on-nothing trick with success.")
+					return shortcut, nil
+				}
+			}
+
 			for _, rr := range recordHolder {
 				/// first of all validate RR
 				// if !contextIndependentValidateRR(rr, token) {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1763,11 +1763,11 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
 				response.SetRcode(r, dns.RcodeNameError)
 			}
+			elogger.Flush(l)
 		} else {
 			elogger.Queuef("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
 			response.SetRcode(r, dns.RcodeSuccess)
 		}
-		elogger.Flush(l)
 
 		response.RecursionAvailable = true
 		if qp.chainOfTrustIntact && qp.CDFlagSet != true {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1820,9 +1820,8 @@ func ServeDNS(cfg runtime.RecursorConfig, rt *runtime.Runtime, v4 bool, net stri
 			panic(fmt.Sprintf("Cannot obtain root trust anchors. [%v]\n", e))
 		}
 	}
-	if provider == dnsProviderOpennic {
-		transferRootZone(lg, provider)
-	}
+
+	transferRootZone(lg, provider)
 
 	pchan := make(chan interface{}, 1)
 	srv := &dns.Server{Addr: addr, Net: net, NotifyStartedFunc: notifyStarted, Handler: dns.HandlerFunc(dnsRecoverWrap(handleDNSMessage(lg, provider, net, rt), pchan))}

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1783,7 +1783,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			}
 			elogger.Flush(l)
 		} else {
-			elogger.Queuef("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
+			l.Infof("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
 			response.SetRcode(r, dns.RcodeSuccess)
 		}
 

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -191,7 +191,7 @@ func (q *queryParam) debug(format string, args ...interface{}) {
 }
 
 func (q *queryParam) setChainOfTrust(b bool) {
-	q.debug("\n\n\nSetting [%v] for chain of trust!!!\n\n\n\n", b)
+	// q.debug("\n\n\nSetting [%v] for chain of trust!!!\n\n\n\n", b)
 	q.chainOfTrustIntact = b
 }
 
@@ -326,7 +326,8 @@ func storeCache(provider, domain string, _recordLiteral interface{}) (time.Durat
 			}
 			// timeBytes, _ := time.Now().Add(time.Duration(rr.Header().Ttl) * time.Second).MarshalText()
 			// logger.debug("Trying to store [%s/%s] [%v] for [%d]\n", provider, domain, rr, rr.Header().Ttl)
-			t.Add(rr.String(), time.Duration(rr.Header().Ttl+1)*time.Second, nil)
+			strToAdd := strings.ToLower(rr.String())
+			t.Add(strToAdd, time.Duration(rr.Header().Ttl+1)*time.Second, nil)
 		}
 		/// shortcut ttl out so no RR scanning steps are needed to determine cache freshness
 		/// save the RR in string form, instead of wire form, it's just faster
@@ -404,7 +405,8 @@ func (q *queryParam) storeCache(provider, domain string, _recordLiteral interfac
 
 			// timeBytes, _ := time.Now().Add(time.Duration(rr.Header().Ttl) * time.Second).MarshalText()
 			q.debug("Trying to store [%s/%s] [%v] for [%d]\n", provider, domain, rr, rr.Header().Ttl)
-			t.Add(rr.String(), time.Duration(rr.Header().Ttl+1)*time.Second, q.chainOfTrustIntact)
+			strToAdd := strings.ToLower(rr.String())
+			t.Add(strToAdd, time.Duration(rr.Header().Ttl+1)*time.Second, q.chainOfTrustIntact)
 		}
 		for i, ptr := range ulteriorRR {
 			q.storeCache(provider, ulteriorDomain[i], []dns.RR{ptr})
@@ -1581,12 +1583,12 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 						q.debug("Sub-Resolve end >>>[%s]\n\n", tHost)
 						q.timeWasted += newq.timeWasted
 						/// the fear that the final A query will result in an unhandled CNAME makes this hack a life-saver
-						if token == q.vanilla {
-							q.debug("TargetServer found out in last iteration, launching continuation to avoid unhandled CNAME.\n")
-							nnewq := q.newContinationParam(len(q.tokens)-1, targetServer)
-							defer nnewq.join()
-							return nnewq.doResolve(resolveMethodRecursive)
-						}
+						// if token == q.vanilla {
+						// 	q.debug("TargetServer found out in last iteration, launching continuation to avoid unhandled CNAME.\n")
+						// 	nnewq := q.newContinationParam(len(q.tokens)-1, targetServer)
+						// 	defer nnewq.join()
+						// 	return nnewq.doResolve(resolveMethodRecursive)
+						// }
 						break
 					}
 				}

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -77,7 +77,7 @@ const (
 	errorCacheTimeFormat        /// time format error
 	errorLoopDetected           /// resolving loop
 	errorInvalidArgument        /// invalid argument supplied to one of the functions
-	errorUnresolvable           /// the domain specified cannot be resolved
+	errorUnresolvable           /// the domain specified cannot be resolved, as in, somewhere in the stack, an irrevocable NXDOMAIN popped up
 	errorDNSSECBogus            /// bogus dnssec-specific record, drop resolve pursuant to rfc considerations
 )
 
@@ -1758,7 +1758,9 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			if err.errorCode != errorUnresolvable && err.errorCode != errorCannotResolve {
 				elogger.Queuef("Failed for [%s -- %d] - [%s]", qp.vanilla, qp.record, err)
 				rt.Stats.Count(StatsQueryFailure)
-				response.SetRcode(r, dns.RcodeServerFailure)
+				if err.errorCode == errorUnresolvable {
+					response.SetRcode(r, dns.RcodeServerFailure)
+				}
 			} else {
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
 				response.SetRcode(r, dns.RcodeNameError)

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1207,6 +1207,7 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 			}
 			oldTargetServer := targetServer
 			targetServer = ""
+			fallbackServers = nil
 			targetHost := make([]string, 0)
 			hasNSRecord, hasARecord, hasCNAMERecord, hasSOARecord, hasDSRecord := false, false, false, false, false
 			// if all goes well, reply should hold `answer` in authority section (appended with eventual glue records in additional)
@@ -1486,9 +1487,9 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 							}
 						}
 					}
-					if targetServer != "" {
-						continue
-					}
+					// if targetServer != "" {
+					// 	continue
+					// }
 				}
 				if hasARecord {
 					/// this should not be happening

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1827,6 +1827,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 				}
 			}
 			elogger.Flush(l)
+			rt.SlackWH.SendFeedback(runtime.NewPayload(qp.vanilla, err.String(), ""))
 		} else {
 			l.Infof("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
 			response.SetRcode(r, dns.RcodeSuccess)
@@ -1859,6 +1860,8 @@ func ServeDNS(cfg runtime.RecursorConfig, rt *runtime.Runtime, v4 bool, net stri
 	lg := nlog.GetLogger("dnsrecursor").WithField("host_name", d.HostName).WithField("address", ip).WithField("port", port).WithField("proto", net)
 	logger.ilog = lg
 
+	rt.SlackWH.SendMessage(fmt.Sprintf("Tenta DNS Operator for %s over %s started up.", provider, net))
+
 	notifyStarted := func() {
 		lg.Infof("Started %s dns recursor on %s", net, addr)
 	}
@@ -1878,6 +1881,7 @@ func ServeDNS(cfg runtime.RecursorConfig, rt *runtime.Runtime, v4 bool, net stri
 	defer rt.OnFinishedOrPanic(func() {
 		srv.Shutdown()
 		lg.Infof("Stopped %s dns resolver on %s", net, addr)
+		rt.SlackWH.SendMessage(fmt.Sprintf("Tenta DNS Operator for %s over %s shutting down.", provider, net))
 	}, pchan)
 
 	if net == "tls" {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -27,25 +27,19 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"github.com/miekg/dns"
+	"github.com/muesli/cache2go"
+	"github.com/sirupsen/logrus"
 	"log"
 	"math/rand"
 	"net"
-	"net/http"
 	"os"
 	"reflect"
 	"strings"
-	"time"
-
-	"github.com/sirupsen/logrus"
-
-	"github.com/miekg/dns"
-	"github.com/muesli/cache2go"
-
 	nlog "tenta-dns/log"
-	runtime "tenta-dns/runtime"
+	"tenta-dns/runtime"
+	"time"
 )
 
 const (
@@ -1679,81 +1673,6 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 	}
 	q.debug("\n\n\nFinishing doResolve for [%s] successfully with [%s]\n\n\n", q.vanilla, q.result)
 	return resultRR, nil
-}
-
-/// TODO -- externalize this call (to a truly side channel), and perhaps supply to the daemon via a config directive
-func getTrustedRootAnchors(l *logrus.Entry, provider string) error {
-	rootDS := make([]dns.RR, 0)
-
-	if provider == "tenta" {
-		data, err := http.Get(rootAnchorURL)
-		if err != nil {
-			return fmt.Errorf("Trusted root anchor obtain failed [%s]", err)
-		}
-		defer data.Body.Close()
-		rootCertData, err := ioutil.ReadAll(data.Body)
-		if err != nil {
-			return fmt.Errorf("Cannot read response data [%s]", err)
-		}
-
-		r := resultData{}
-		if err := xml.Unmarshal([]byte(rootCertData), &r); err != nil {
-			return fmt.Errorf("Problem during unmarshal. [%s]", err)
-		}
-
-		for _, dsData := range r.KeyDigest {
-			deleg := new(dns.DS)
-			deleg.Hdr = dns.RR_Header{Name: ".", Rrtype: dns.TypeDS, Class: dns.ClassINET, Ttl: 14400, Rdlength: 0}
-			deleg.Algorithm = dsData.Algorithm
-			deleg.Digest = dsData.Digest
-			deleg.DigestType = dsData.DigestType
-			deleg.KeyTag = dsData.KeyTag
-			rootDS = append(rootDS, deleg)
-		}
-
-	} else if provider == "opennic" {
-		q := newQueryParam(".", dns.TypeDNSKEY, l, new(nlog.EventualLogger), provider)
-		krr, e := q.doResolve(resolveMethodFinalQuestion)
-		if e != nil {
-			return fmt.Errorf("Cannot get opennic root keys. [%s]", e.Error())
-		}
-		for _, rr := range krr {
-			if k, ok := rr.(*dns.DNSKEY); ok {
-				rootDS = append(rootDS, k.ToDS(2))
-			}
-		}
-	}
-	storeCache(provider, ".", rootDS)
-
-	return nil
-}
-
-/// block until zone is transferred
-/// todo: validate rrs
-func transferRootZone(l *logrus.Entry, provider string) error {
-	t := new(dns.Transfer)
-	m := new(dns.Msg)
-	m.SetAxfr(".")
-	r, e := t.In(m, rootServers[provider][0].ipv4+":53")
-	if e != nil {
-		return fmt.Errorf("cannot execute zone transfer [%s]", e.Error())
-	}
-
-	for env := range r {
-		if env.Error != nil {
-			l.Infof("Zone transfer envelope error [%s]", env.Error.Error())
-			continue
-		}
-		for _, rr := range env.RR {
-			switch rr.(type) {
-			case *dns.A, *dns.AAAA, *dns.NS:
-				storeCache(provider, rr.Header().Name, []dns.RR{rr})
-			}
-		}
-
-	}
-
-	return nil
 }
 
 func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime.Runtime) dnsHandler {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1778,7 +1778,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			}
 			elogger.Flush(l)
 		} else {
-			elogger.Queuef("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
+			l.Infof("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
 			response.SetRcode(r, dns.RcodeSuccess)
 		}
 

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1758,7 +1758,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 
 		l = l.WithField("domain", r.Question[0].Name)
 		elogger := new(nlog.EventualLogger)
-		elogger.Queuef("%v -- STARTING NEW TOPLEVEL RESOLVE FOR [%s]", time.Now(), r.Question[0].Name)
+		elogger.Queuef("%v -- STARTING NEW TOPLEVEL RESOLVE FOR [%s][RecDesired - %v]", time.Now(), r.Question[0].Name, r.RecursionDesired)
 		qp := newQueryParam(r.Question[0].Name, r.Question[0].Qtype, l, elogger, provider)
 		qp.CDFlagSet = r.CheckingDisabled
 		resolveMethodToUse := resolveMethodRecursive

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1743,29 +1743,31 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 	}
 }
 
-// ServeDNS -- Entry point for DNS recursor
 func ServeDNS(cfg runtime.RecursorConfig, rt *runtime.Runtime, v4 bool, net string, d *runtime.ServerDomain, opennicMode bool, dnssecMode bool) {
-	/// set up old variables
+	// TODO: Get rid of these old variables variables
 	*dnssecEnabled = dnssecMode
-	provider := "tenta"
 	*debugLevel = true
+
+	provider := "tenta"
 	if opennicMode == true {
 		provider = "opennic"
 	}
+
 	ip, port := hostInfo(v4, net, d)
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	lg := nlog.GetLogger("dnsrecursor").WithField("host_name", d.HostName).WithField("address", ip).WithField("port", port).WithField("proto", net)
 	logger.ilog = lg
+
 	notifyStarted := func() {
 		lg.Infof("Started %s dns recursor on %s", net, addr)
 	}
 	lg.Debugf("Preparing %s dns recursor on %s", net, addr)
-	if *dnssecEnabled {
+
+	if dnssecMode {
 		if e := getTrustedRootAnchors(lg, provider); e != nil {
 			panic(fmt.Sprintf("Cannot obtain root trust anchors. [%v]\n", e))
 		}
 	}
-
 	if provider == dnsProviderOpennic {
 		transferRootZone(lg, provider)
 	}

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -990,7 +990,10 @@ func (q *queryParam) simpleResolve(object, target string, subject uint16) (*dns.
 
 	if err != nil {
 		return nil, t, newError(errorCannotResolve, severityFatal, "simpleResolve failed. [%s]", err)
+	} else if reply.Rcode == dns.RcodeServerFailure {
+		return nil, t, newError(errorCannotResolve, severityNuisance, "simpleResolve got SERVFAIL.")
 	}
+
 	q.debug("Dns rountrip time is [%v]\n", rtt)
 
 	for q.chainOfTrustIntact && subject != dns.TypeDNSKEY {

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -110,7 +110,7 @@ var (
 	certCache            = func() *string { t := ""; return &t }()    //flag.String("certcache", "", "Use the specified path for local certificate cache")
 	dnssecEnabled        = func() *bool { t := false; return &t }()   //flag.Bool("dnssec", false, "starts server in dnssec enabled mode")
 	forgivingDNSSECCheck = true
-	preferredProtocol    = "tcp"
+	preferredProtocol    = "udp"
 	/// TODO -- externalize as a config directive the ips of root servers (both iana and opennic)
 	opennicRoots    = []*rootServer{&rootServer{"ns2.opennic.glue", "161.97.219.84", "2001:470:4212:10:0:100:53:1"}}
 	ianaRoots       = []*rootServer{&rootServer{"b.root-servers.net", "192.228.79.201", "2001:500:84::b"}}

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1778,7 +1778,7 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			}
 			elogger.Flush(l)
 		} else {
-			l.Infof("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
+			elogger.Queuef("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
 			response.SetRcode(r, dns.RcodeSuccess)
 		}
 

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1677,17 +1677,8 @@ func (q *queryParam) doResolve(resolveTechnique int) (resultRR []dns.RR, e *dnsE
 
 func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime.Runtime) dnsHandler {
 	l := loggy
-	return func(w dns.ResponseWriter, m *dns.Msg) {
-		if strings.Contains(m.Question[0].String(), "vkcache") || m.Question[0].Qtype == dns.TypeANY {
-			return
-		}
-		/// check with rate limiter (and save to stats on false)
-
-		if network == "udp" && !net.ParseIP(w.RemoteAddr().String()).IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
-			rt.Stats.Tick("resolver", "throttled")
-			rt.Stats.Card(StatsQueryLimitedIps, w.RemoteAddr().String())
-			return
-		}
+	return func(w dns.ResponseWriter, r *dns.Msg) {
+		startTime := time.Now()
 		rt.Stats.Count(StatsQueryTotal)
 		if network == "udp" {
 			rt.Stats.Count(StatsQueryUDP)
@@ -1701,14 +1692,31 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 		rt.Stats.Tick("dns", "queries:all")
 		rt.Stats.Tick("dns", "queries:recursive")
 		rt.Stats.Card(StatsQueryUniqueIps, w.RemoteAddr().String())
-		startTime := time.Now()
-		l = l.WithField("domain", m.Question[0].Name)
+
+		if strings.Contains(r.Question[0].String(), "vkcache") || r.Question[0].Qtype == dns.TypeANY {
+			return
+		}
+
+		// Check with rate limiter (and save to stats on false)
+		if network == "udp" && !net.ParseIP(w.RemoteAddr().String()).IsLoopback() && !rt.RateLimiter.CountAndPass(net.ParseIP(w.RemoteAddr().String())) {
+			rt.Stats.Tick("resolver", "throttled")
+			rt.Stats.Card(StatsQueryLimitedIps, w.RemoteAddr().String())
+			return
+		}
+
+		// Don't allow ANY over UDP
+		if network == "udp" && r.Question[0].Qtype == dns.TypeANY {
+			refuseAny(w, r, rt)
+			return
+		}
+
+		l = l.WithField("domain", r.Question[0].Name)
 		elogger := new(nlog.EventualLogger)
-		elogger.Queuef("%v -- STARTING NEW TOPLEVEL RESOLVE FOR [%s]", time.Now(), m.Question[0].Name)
-		qp := newQueryParam(m.Question[0].Name, m.Question[0].Qtype, l, elogger, provider)
-		qp.CDFlagSet = m.CheckingDisabled
+		elogger.Queuef("%v -- STARTING NEW TOPLEVEL RESOLVE FOR [%s]", time.Now(), r.Question[0].Name)
+		qp := newQueryParam(r.Question[0].Name, r.Question[0].Qtype, l, elogger, provider)
+		qp.CDFlagSet = r.CheckingDisabled
 		resolveMethodToUse := resolveMethodRecursive
-		if m.RecursionDesired == false {
+		if r.RecursionDesired == false {
 			resolveMethodToUse = resolveMethodCacheOnly
 		}
 		qp.chainOfTrustIntact = *dnssecEnabled
@@ -1720,15 +1728,15 @@ func handleDNSMessage(loggy *logrus.Entry, provider, network string, rt *runtime
 			if err.errorCode != errorUnresolvable && err.errorCode != errorCannotResolve {
 				elogger.Queuef("Failed for [%s -- %d] - [%s]", qp.vanilla, qp.record, err)
 				rt.Stats.Count(StatsQueryFailure)
-				response.SetRcode(m, dns.RcodeServerFailure)
+				response.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				elogger.Queuef("[%s -- %d] unresolvable.", qp.vanilla, qp.record)
-				response.SetRcode(m, dns.RcodeNameError)
+				response.SetRcode(r, dns.RcodeNameError)
 			}
 			elogger.Flush(l)
 		} else {
 			elogger.Queuef("ANSWER is: [%v][%v][%s]", resolvTime, qp.timeWasted, answer)
-			response.SetRcode(m, dns.RcodeSuccess)
+			response.SetRcode(r, dns.RcodeSuccess)
 		}
 
 		response.RecursionAvailable = true

--- a/src/tenta-dns/responder/recursive_dns.go
+++ b/src/tenta-dns/responder/recursive_dns.go
@@ -1833,32 +1833,7 @@ func ServeDNS(cfg runtime.RecursorConfig, rt *runtime.Runtime, v4 bool, net stri
 	if opennicMode == true {
 		provider = "opennic"
 	}
-	var ip string
-	if v4 {
-		ip = d.IPv4
-	} else {
-		ip = fmt.Sprintf("[%s]", d.IPv6)
-	}
-	var port int
-	if net == "tcp" {
-		if d.DnsTcpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TCP recursive DNS server without a valid TCP port")
-		}
-		port = d.DnsTcpPort
-	} else if net == "udp" {
-		if d.DnsUdpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a UDP recursive DNS server without a valid UDP port")
-		}
-		port = d.DnsUdpPort
-	} else if net == "tls" {
-		if d.DnsTlsPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TLS recursive DNS server without a valid TLS port")
-		}
-		port = d.DnsTlsPort
-	} else {
-		nlog.GetLogger("dnsrecursor").Warnf("Unknown DNS net type %s", net)
-		return
-	}
+	ip, port := hostInfo(v4, net, d)
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	lg := nlog.GetLogger("dnsrecursor").WithField("host_name", d.HostName).WithField("address", ip).WithField("port", port).WithField("proto", net)
 	logger.ilog = lg

--- a/src/tenta-dns/responder/recursive_dns_helpers.go
+++ b/src/tenta-dns/responder/recursive_dns_helpers.go
@@ -1,0 +1,21 @@
+package responder
+
+import (
+	"github.com/miekg/dns"
+	"tenta-dns/runtime"
+)
+
+// Politely decline to answer ANY queries
+func refuseAny(w dns.ResponseWriter, r *dns.Msg, rt *runtime.Runtime) {
+	rt.Stats.Tick("resolver", "refuse-any")
+	hinfo := &dns.HINFO{
+		Cpu: "ANY obsolete",
+		Os: "See draft-ietf-dnsop-refuse-any",
+	}
+	msg := new(dns.Msg)
+	msg.SetReply(r)
+	msg.Compress = true
+	msg.Answer = append(msg.Answer, hinfo)
+	msg.SetRcode(r, dns.RcodeSuccess)
+	w.WriteMsg(msg)
+}

--- a/src/tenta-dns/responder/snitch_dns.go
+++ b/src/tenta-dns/responder/snitch_dns.go
@@ -45,32 +45,7 @@ func SnitchDNSServer(cfg runtime.NSnitchConfig, rt *runtime.Runtime, v4 bool, ne
 }
 
 func serveSnitchDNS(cfg runtime.NSnitchConfig, rt *runtime.Runtime, v4 bool, net string, d *runtime.ServerDomain) {
-	var ip string
-	if v4 {
-		ip = d.IPv4
-	} else {
-		ip = fmt.Sprintf("[%s]", d.IPv6)
-	}
-	var port int
-	if net == "tcp" {
-		if d.DnsTcpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TCP snitch without a valid TCP port")
-		}
-		port = d.DnsTcpPort
-	} else if net == "udp" {
-		if d.DnsUdpPort <= runtime.PORT_UNSET {
-			panic("Unable to start a UDP snitch without a valid TCP port")
-		}
-		port = d.DnsUdpPort
-	} else if net == "tls" {
-		if d.DnsTlsPort <= runtime.PORT_UNSET {
-			panic("Unable to start a TLS snitch without a valid TLS port")
-		}
-		port = d.DnsTlsPort
-	} else {
-		log.GetLogger("dnsnitch").Warnf("Unknown DNS net type %s", net)
-		return
-	}
+	ip, port := hostInfo(v4, net, d)
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	lg := log.GetLogger("dnsnitch").WithField("host_name", d.HostName).WithField("address", ip).WithField("port", port).WithField("proto", net)
 	notifyStarted := func() {

--- a/src/tenta-dns/runtime/config.go
+++ b/src/tenta-dns/runtime/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	DefaultDnsTlsPort int
 	RateThreshold     uint64
 	OutboundIPs       []string
+	SlackFeedback     map[string]string
 }
 
 type NSnitchConfig struct {

--- a/src/tenta-dns/runtime/config.go
+++ b/src/tenta-dns/runtime/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	DefaultDnsTcpPort int
 	DefaultDnsTlsPort int
 	RateThreshold     uint64
+	OutboundIPs       []string
 }
 
 type NSnitchConfig struct {

--- a/src/tenta-dns/runtime/feedback.go
+++ b/src/tenta-dns/runtime/feedback.go
@@ -35,7 +35,7 @@ import (
 )
 
 type Payload struct {
-	dom, err, stack string
+	operator, dom, err, stack string
 }
 
 type Feedback struct {
@@ -49,15 +49,15 @@ type Feedback struct {
 
 func (p *Payload) ShortEncode() []byte {
 
-	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Error occured resolving domain `%s`\n`%s`\"}", p.dom, p.err)))
+	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Operator `%s` failed to resolve domain `%s`\n`%s`\"}", p.operator, p.dom, p.err)))
 }
 
 func (p *Payload) LongEncode() []byte {
-	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Error occured resolving domain `%s`\n`%s`\n%s\"}", p.dom, p.err, p.stack)))
+	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Operator `%s` failed to resolve domain `%s`\n`%s`\n%s\"}", p.dom, p.err, p.stack)))
 }
 
-func NewPayload(dom, err, stack string) *Payload {
-	return &Payload{dom: dom, err: err, stack: stack}
+func NewPayload(operator, dom, err, stack string) *Payload {
+	return &Payload{operator: operator, dom: dom, err: err, stack: stack}
 }
 
 func StartFeedback(cfg Config, rt *Runtime) *Feedback {

--- a/src/tenta-dns/runtime/feedback.go
+++ b/src/tenta-dns/runtime/feedback.go
@@ -1,0 +1,121 @@
+/**
+ * Tenta DNS Server
+ *
+ *    Copyright 2017 Tenta, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions, please contact developer@tenta.io
+ *
+ * feedback.go: Provides primitives for Slack webhook notifications
+ */
+
+package runtime
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"tenta-dns/log"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Payload struct {
+	dom, err, stack string
+}
+
+type Feedback struct {
+	nopmode bool
+	msg     chan []byte
+	stop    chan bool
+	wg      *sync.WaitGroup
+	whURL   string
+	l       *logrus.Entry
+}
+
+func (p *Payload) ShortEncode() []byte {
+
+	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Error occured resolving domain `%s`\n`%s`\"}", p.dom, p.err)))
+}
+
+func (p *Payload) LongEncode() []byte {
+	return []byte("payload=" + url.QueryEscape(fmt.Sprintf("{\"text\":\"Error occured resolving domain `%s`\n`%s`\n%s\"}", p.dom, p.err, p.stack)))
+}
+
+func NewPayload(dom, err, stack string) *Payload {
+	return &Payload{dom: dom, err: err, stack: stack}
+}
+
+func StartFeedback(cfg Config, rt *Runtime) *Feedback {
+	f := &Feedback{}
+	if t, ok := cfg.SlackFeedback["url"]; !ok {
+		f.nopmode = true
+	} else {
+		f.msg = make(chan []byte)
+		f.stop = make(chan bool)
+		f.whURL = t
+		f.l = log.GetLogger("feedback")
+		wg := &sync.WaitGroup{}
+		f.wg = wg
+		go f.startFeedbackService()
+		f.wg.Add(1)
+		f.l.Infof("Started Feedback service")
+	}
+	return f
+}
+
+func (f *Feedback) SendFeedback(p *Payload) {
+	if !f.nopmode {
+		f.msg <- p.ShortEncode()
+	}
+}
+
+func (f *Feedback) SendMessage(s string) {
+	if !f.nopmode {
+		m := "payload=" + url.QueryEscape(fmt.Sprintf("{\"text\": \"%s\"}", s))
+		f.msg <- []byte(m)
+	}
+}
+
+func (f *Feedback) startFeedbackService() {
+	defer f.wg.Done()
+	for {
+		select {
+		case <-f.stop:
+			f.l.Infof("Stop signal received. Exiting.")
+			return
+		case b := <-f.msg:
+			resp, err := http.Post(f.whURL, "application/x-www-form-urlencoded", bytes.NewReader(b))
+			defer resp.Body.Close()
+			if err != nil {
+				f.l.Infof("Unable to send to Slack. Cause [%s]", err.Error())
+			} else if resp.StatusCode != 200 {
+				f.l.Infof("Unable to send to Slack. HTTP status [%d]", resp.StatusCode)
+			}
+			break
+		case <-time.After(100 * time.Millisecond):
+			break
+		}
+	}
+}
+
+func (f *Feedback) Stop() {
+	if !f.nopmode {
+		defer f.wg.Wait()
+		f.stop <- true
+	}
+}

--- a/src/tenta-dns/runtime/ippool.go
+++ b/src/tenta-dns/runtime/ippool.go
@@ -1,0 +1,85 @@
+/**
+ * Tenta DNS Server
+ *
+ *    Copyright 2017 Tenta, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For any questions, please contact developer@tenta.io
+ *
+ * ippool.go: Manages IP pool rotation
+ */
+
+package runtime
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"tenta-dns/log"
+	"time"
+)
+
+type Pool struct {
+	p []net.Addr
+	r *rand.Rand
+}
+
+func ListAvailableIPs() ([]net.Addr, error) {
+	ret := make([]net.Addr, 0)
+	ifs, e := net.Interfaces()
+	l := log.GetLogger("common")
+	if e != nil {
+		l.Fatalf("Cannot query local interfaces")
+		panic(fmt.Sprintf("Cannot query network interfaces", e.Error()))
+	}
+
+	for _, intf := range ifs {
+		l.Debugf("Scanning intf [%s]", intf.Name)
+		if addrs, e := intf.Addrs(); e == nil {
+			for _, addr := range addrs {
+				l.Debugf("Scanning address [%s]", addr.String())
+
+				switch a := addr.(type) {
+				case *net.IPNet:
+					if a.IP.IsGlobalUnicast() { //} && !common.IsPrivateIp(a.IP) {
+						ret = append(ret, addr)
+					}
+				case *net.IPAddr:
+					if a.IP.IsGlobalUnicast() { //} && !common.IsPrivateIp(a.IP) {
+						ret = append(ret, addr)
+					}
+				}
+			}
+		}
+	}
+	if len(ret) == 0 {
+		panic(fmt.Sprintf("Empty ip pool"))
+	}
+	return ret, nil
+}
+
+func StartIPPool() *Pool {
+	l := log.GetLogger("runtime")
+	ips, e := ListAvailableIPs()
+	if e != nil {
+		l.Fatalf("Cannot get list of available IP addresses [%s]", e.Error())
+		panic(e)
+	}
+	l.Infof("Initialized IP Pool with [%v]", ips)
+	return &Pool{ips, rand.New(rand.NewSource(time.Now().UnixNano()))}
+}
+
+func (p *Pool) RandomizeIP() net.Addr {
+	return p.p[p.r.Intn(len(p.p)-1)]
+}

--- a/src/tenta-dns/runtime/ippool.go
+++ b/src/tenta-dns/runtime/ippool.go
@@ -31,12 +31,12 @@ import (
 )
 
 type Pool struct {
-	p []net.Addr
+	p []net.IP
 	r *rand.Rand
 }
 
-func ListAvailableIPs() ([]net.Addr, error) {
-	ret := make([]net.Addr, 0)
+func ListAvailableIPs() ([]net.IP, error) {
+	ret := make([]net.IP, 0)
 	ifs, e := net.Interfaces()
 	l := log.GetLogger("common")
 	if e != nil {
@@ -49,15 +49,14 @@ func ListAvailableIPs() ([]net.Addr, error) {
 		if addrs, e := intf.Addrs(); e == nil {
 			for _, addr := range addrs {
 				l.Debugf("Scanning address [%s]", addr.String())
-
 				switch a := addr.(type) {
 				case *net.IPNet:
 					if a.IP.IsGlobalUnicast() { //} && !common.IsPrivateIp(a.IP) {
-						ret = append(ret, addr)
+						ret = append(ret, a.IP)
 					}
 				case *net.IPAddr:
 					if a.IP.IsGlobalUnicast() { //} && !common.IsPrivateIp(a.IP) {
-						ret = append(ret, addr)
+						ret = append(ret, a.IP)
 					}
 				}
 			}
@@ -80,6 +79,12 @@ func StartIPPool() *Pool {
 	return &Pool{ips, rand.New(rand.NewSource(time.Now().UnixNano()))}
 }
 
-func (p *Pool) RandomizeIP() net.Addr {
-	return p.p[p.r.Intn(len(p.p)-1)]
+func (p *Pool) RandomizeUDPAddr() *net.UDPAddr {
+	t := p.p[p.r.Intn(len(p.p)-1)]
+	return &net.UDPAddr{IP: t}
+}
+
+func (p *Pool) RandomizeTCPAddr() *net.TCPAddr {
+	t := p.p[p.r.Intn(len(p.p)-1)]
+	return &net.TCPAddr{IP: t}
 }

--- a/src/tenta-dns/runtime/ippool.go
+++ b/src/tenta-dns/runtime/ippool.go
@@ -55,7 +55,7 @@ func StartIPPool(cfgIPs []string) *Pool {
 func (p *Pool) RandomizeUDPDialer() *net.Dialer {
 	ret := &net.Dialer{}
 	if len(p.p) > 0 {
-		ret.LocalAddr = &net.UDPAddr{IP: p.p[p.r.Intn(len(p.p)-1)]}
+		ret.LocalAddr = &net.UDPAddr{IP: p.p[p.r.Intn(len(p.p))]}
 	}
 	return ret
 }
@@ -63,7 +63,7 @@ func (p *Pool) RandomizeUDPDialer() *net.Dialer {
 func (p *Pool) RandomizeTCPDialer() *net.Dialer {
 	ret := &net.Dialer{}
 	if len(p.p) > 0 {
-		ret.LocalAddr = &net.TCPAddr{IP: p.p[p.r.Intn(len(p.p)-1)]}
+		ret.LocalAddr = &net.TCPAddr{IP: p.p[p.r.Intn(len(p.p))]}
 	}
 	return ret
 }

--- a/src/tenta-dns/runtime/ippool.go
+++ b/src/tenta-dns/runtime/ippool.go
@@ -41,7 +41,7 @@ func StartIPPool(cfgIPs []string) *Pool {
 		l.Infof("Starting without any outbound IP specified. Default IP will be used.")
 		ips = nil
 	} else {
-		ips := make([]net.IP, 0)
+		ips = make([]net.IP, 0)
 		for _, strIP := range cfgIPs {
 			ip := net.ParseIP(strIP)
 			ips = append(ips, ip)

--- a/src/tenta-dns/runtime/runtime.go
+++ b/src/tenta-dns/runtime/runtime.go
@@ -84,7 +84,7 @@ func NewRuntime(cfg Config) *Runtime {
 		panic(err)
 	}
 
-	rt.IPPool = StartIPPool()
+	rt.IPPool = StartIPPool(cfg.OutboundIPs)
 	rt.Stats = StartStats(rt)
 	rt.RateLimiter = StartLimiter(cfg.RateThreshold)
 	rt.AddService()

--- a/src/tenta-dns/runtime/runtime.go
+++ b/src/tenta-dns/runtime/runtime.go
@@ -43,6 +43,7 @@ type Runtime struct {
 	DB          *leveldb.DB
 	Geo         *Geo
 	Stats       *Stats
+	IPPool      *Pool
 	stop        chan bool
 	started     uint
 	lg          *logrus.Entry
@@ -83,6 +84,7 @@ func NewRuntime(cfg Config) *Runtime {
 		panic(err)
 	}
 
+	rt.IPPool = StartIPPool()
 	rt.Stats = StartStats(rt)
 	rt.RateLimiter = StartLimiter(cfg.RateThreshold)
 	rt.AddService()

--- a/src/tenta-dns/runtime/runtime.go
+++ b/src/tenta-dns/runtime/runtime.go
@@ -48,6 +48,7 @@ type Runtime struct {
 	started     uint
 	lg          *logrus.Entry
 	RateLimiter *Limiter
+	SlackWH     *Feedback
 }
 
 type finisher func()
@@ -85,6 +86,7 @@ func NewRuntime(cfg Config) *Runtime {
 	}
 
 	rt.IPPool = StartIPPool(cfg.OutboundIPs)
+	rt.SlackWH = StartFeedback(cfg, rt)
 	rt.Stats = StartStats(rt)
 	rt.RateLimiter = StartLimiter(cfg.RateThreshold)
 	rt.AddService()
@@ -145,6 +147,7 @@ func (rt *Runtime) Shutdown() {
 		rt.stop <- true
 	}
 	rt.wg.Wait()
+	rt.SlackWH.Stop()
 	rt.Stats.Stop()
 	rt.DB.Close()
 	rt.lg.Info("Shutdown complete")

--- a/src/tenta-dns/runtime/stats.go
+++ b/src/tenta-dns/runtime/stats.go
@@ -31,11 +31,11 @@ import (
 	"tenta-dns/log"
 	"time"
 
-	"github.com/dgryski/go-highway"
 	"github.com/sasha-s/go-hll"
 	"github.com/sirupsen/logrus"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/tenta-browser/go-highway"
 )
 
 type EventType uint8

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -13,30 +13,34 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
 	"tenta-dns/log"
 	"time"
-	"os"
 )
 
 var (
-	ip      = flag.String("ip", "127.0.0.1", "IP address to stress")
-	port    = flag.Uint("port", 53, "Port to test")
-	tcp     = flag.Bool("tcp", false, "Whether to use TCP mode")
-	tls     = flag.Bool("tls", false, "Whether to use TLS (implies -tcp)")
-	workers = flag.Uint("workers", 0, "Number of simultaneous test workers to run (0 => autoselect)")
-	quiet   = flag.Bool("quiet", false, "Don't produce any output to the terminal")
-	verbose = flag.Bool("verbose", false, "Produce lots of output to the terminal (overrides the -quiet flag)")
-	limit   = flag.Uint("limit", 1000, "How many domain names to use in the test (max 1000000)")
-	errfile = flag.String("errfile", "", "If specified, write errors to this file")
+	ip       = flag.String("ip", "127.0.0.1", "IP address to stress")
+	port     = flag.Uint("port", 53, "Port to test")
+	tcp      = flag.Bool("tcp", false, "Whether to use TCP mode")
+	tls      = flag.Bool("tls", false, "Whether to use TLS (implies -tcp)")
+	workers  = flag.Uint("workers", 0, "Number of simultaneous test workers to run (0 => autoselect)")
+	quiet    = flag.Bool("quiet", false, "Don't produce any output to the terminal")
+	verbose  = flag.Bool("verbose", false, "Produce lots of output to the terminal (overrides the -quiet flag)")
+	limit    = flag.Uint("limit", 1000, "How many domain names to use in the test (max 1000000)")
+	errfile  = flag.String("errfile", "", "If specified, write errors to this file")
+	printver = flag.Bool("version", false, "Print the version and exit")
 )
+
+var version string
 
 const alexaUrl = "https://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
 
 func usage() {
-	fmt.Println("Tenta DNS Stresser")
+	fmt.Printf("Tenta DNS Stresser %s", version)
+	fmt.Println()
 	fmt.Println("Testing harness for Tenta DNS")
 	fmt.Println("Options:")
 	flag.PrintDefaults()
@@ -46,6 +50,11 @@ func main() {
 	log.SetLogLevel(logrus.InfoLevel)
 	flag.Usage = usage
 	flag.Parse()
+
+	if *printver {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	if *quiet {
 		log.SetLogLevel(logrus.FatalLevel)
@@ -105,7 +114,7 @@ func main() {
 type result struct {
 	name    string
 	time    time.Duration
-	msg string
+	msg     string
 	success bool
 }
 
@@ -247,6 +256,6 @@ func testRecords(r *csv.Reader, num uint, lg *logrus.Entry) {
 			lg.Errorf("Unable to write results file %s: %s", *errfile, err.Error())
 		}
 	}
-	lg.Infof("%d out of %d queries succeeded (%0.02f%%)", success, total, (float64(success) / float64(total))*100)
+	lg.Infof("%d out of %d queries succeeded (%0.02f%%)", success, total, (float64(success)/float64(total))*100)
 	wg.Wait()
 }

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -161,7 +161,7 @@ func (w *worker) doWork(id uint) {
 			c.SingleInflight = true
 			c.DialTimeout = time.Second
 			c.WriteTimeout = time.Second * 3
-			c.ReadTimeout = time.Second * 30
+			c.ReadTimeout = time.Second * 100
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -159,10 +159,9 @@ func (w *worker) doWork(id uint) {
 				c.Net = "tcp-tls"
 			}
 			c.SingleInflight = true
-			// c.DialTimeout = time.Second * 10
-			// c.WriteTimeout = time.Second * 10
-			// c.ReadTimeout = time.Second * 30
-			c.Timeout = time.Second * 300
+			c.DialTimeout = time.Second
+			c.WriteTimeout = time.Second * 3
+			c.ReadTimeout = time.Second * 30
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -24,7 +24,7 @@ import (
 var (
 	ip      = flag.String("ip", "127.0.0.1", "IP address to stress")
 	port    = flag.Uint("port", 53, "Port to test")
-	tcp     = flag.Bool("tcp", true, "Whether to use TCP mode")
+	tcp     = flag.Bool("tcp", false, "Whether to use TCP mode")
 	tls     = flag.Bool("tls", false, "Whether to use TLS (implies -tcp)")
 	workers = flag.Uint("workers", 0, "Number of simultaneous test workers to run (0 => autoselect)")
 	quiet   = flag.Bool("quiet", false, "Don't produce any output to the terminal")

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -161,7 +161,7 @@ func (w *worker) doWork(id uint) {
 			c.SingleInflight = true
 			c.DialTimeout = time.Second
 			c.WriteTimeout = time.Second * 3
-			c.ReadTimeout = time.Second * 100
+			c.ReadTimeout = time.Second * 30
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"runtime"
+	"strconv"
+	"sync"
+	"tenta-dns/log"
+	"time"
+	"os"
+)
+
+var (
+	ip      = flag.String("ip", "127.0.0.1", "IP address to stress")
+	port    = flag.Uint("port", 53, "Port to test")
+	tcp     = flag.Bool("tcp", true, "Whether to use TCP mode")
+	tls     = flag.Bool("tls", false, "Whether to use TLS (implies -tcp)")
+	workers = flag.Uint("workers", 0, "Number of simultaneous test workers to run (0 => autoselect)")
+	quiet   = flag.Bool("quiet", false, "Don't produce any output to the terminal")
+	verbose = flag.Bool("verbose", false, "Produce lots of output to the terminal (overrides the -quiet flag)")
+	limit   = flag.Uint("limit", 1000, "How many domain names to use in the test (max 1000000)")
+	errfile = flag.String("errfile", "", "If specified, write errors to this file")
+)
+
+const alexaUrl = "https://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
+
+func usage() {
+	fmt.Println("Tenta DNS Stresser")
+	fmt.Println("Testing harness for Tenta DNS")
+	fmt.Println("Options:")
+	flag.PrintDefaults()
+}
+
+func main() {
+	log.SetLogLevel(logrus.InfoLevel)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *quiet {
+		log.SetLogLevel(logrus.FatalLevel)
+	}
+	if *verbose {
+		log.SetLogLevel(logrus.DebugLevel)
+	}
+
+	if *workers < 1 {
+		*workers = uint(runtime.NumCPU())
+	}
+	if *workers > 1 {
+		*workers -= 1 // Leave aside a worker to feed the channel
+	}
+
+	lg := log.GetLogger("stresser")
+	start := time.Now()
+	lg.Infof("Starting test with %d workers", *workers)
+	lg.Infof("Resolving up to %d names", *limit)
+
+	resp, err := http.Get(alexaUrl)
+	if err != nil {
+		lg.Errorf("Unable to download domain listing: %s", err.Error())
+	} else {
+		defer resp.Body.Close()
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			lg.Errorf("Unable to read domain listing body: %s", err.Error())
+		} else {
+			r, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+			if err != nil {
+				lg.Errorf("Unable to decode domain listing data as zip: %s", err.Error())
+			} else {
+				lg.Debugf("Got zip file")
+				for _, f := range r.File {
+					lg.Debugf("Found file %s", f.Name)
+					if f.Name == "top-1m.csv" {
+						fr, err := f.Open()
+						defer fr.Close()
+						if err != nil {
+							lg.Errorf("Failure while opening file %s", f.Name)
+						} else {
+							cr := csv.NewReader(fr)
+							testRecords(cr, *workers, lg)
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	duration := time.Now().Sub(start)
+	lg.Infof("Finished in %s", duration.String())
+}
+
+type result struct {
+	name    string
+	time    time.Duration
+	msg string
+	success bool
+}
+
+type worker struct {
+	wg      *sync.WaitGroup
+	lg      *logrus.Entry
+	stop    chan bool
+	work    chan string
+	results chan result
+}
+
+func (w *worker) doWork(id uint) {
+	lg := w.lg.WithField("id", id)
+	defer lg.Debug("Done")
+	w.wg.Add(1)
+	defer w.wg.Done()
+	lg.Debug("Started")
+	run := true
+	for run {
+		select {
+		case <-w.stop:
+			lg.Debug("Got stop command")
+			run = false
+			break
+		case name := <-w.work:
+			start := time.Now()
+			//lg.Debugf("Querying %s", name)
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+			m := new(dns.Msg)
+			m.Id = dns.Id()
+			m.RecursionDesired = true
+			m.CheckingDisabled = false
+			m.Question = make([]dns.Question, 1)
+			m.Question[0] = dns.Question{Name: dns.Fqdn(name), Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			c := new(dns.Client)
+			c.Net = "udp"
+			if *tcp {
+				c.Net = "tcp"
+			}
+			if *tls {
+				c.Net = "tcp-tls"
+			}
+			c.SingleInflight = true
+			c.DialTimeout = time.Second
+			c.WriteTimeout = time.Second * 3
+			c.ReadTimeout = time.Second * 5
+			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
+			s := false
+			msg := ""
+			if err != nil {
+				msg = fmt.Sprintf("Error querying %s: %s", name, err.Error())
+			} else {
+				if in.Rcode != dns.RcodeSuccess {
+					msg = fmt.Sprintf("Got a bad RCode for %s: %s", name, dns.RcodeToString[in.Rcode])
+				} else {
+					s = true
+					msg = fmt.Sprintf("Query for %s OK", name)
+				}
+			}
+			r := result{name: name, time: time.Since(start), success: s, msg: msg}
+			w.results <- r
+			break
+		}
+	}
+}
+
+func testRecords(r *csv.Reader, num uint, lg *logrus.Entry) {
+	wg := &sync.WaitGroup{}
+	workers := make([]worker, 0)
+	work := make(chan string, num*2+1)
+	rc := make(chan result, num*2+1)
+	for i := uint(0); i < num; i += 1 {
+		wrk := worker{wg: wg, lg: lg, stop: make(chan bool, 1), work: work, results: rc}
+		go wrk.doWork(i)
+		workers = append(workers, wrk)
+	}
+	cnt := uint(0)
+	results := make(map[string]result)
+	for {
+		rec, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			lg.Errorf("Failed to read record: %s", err.Error())
+			break
+		}
+		cnt += 1
+		work <- rec[1]
+		select {
+		case r := <-rc:
+			results[r.name] = r
+			break
+		case <-time.After(time.Microsecond):
+			break
+		}
+		if cnt == *limit {
+			break
+		}
+	}
+	for len(work) > 0 {
+		select {
+		case r := <-rc:
+			results[r.name] = r
+			break
+		case <-time.After(time.Microsecond):
+			break
+		}
+	}
+	run := true
+	for run {
+		select {
+		case r := <-rc:
+			results[r.name] = r
+			break
+		case <-time.After(time.Second * 3):
+			run = false
+			break
+		}
+	}
+	for _, w := range workers {
+		w.stop <- true
+	}
+	total := 0
+	success := 0
+	errstr := ""
+	for _, r := range results {
+		total += 1
+		if r.success {
+			success += 1
+		} else {
+			lg.Debugf("%s: failure: %s", r.name, r.msg)
+			errstr += r.msg + "\n"
+		}
+	}
+	if *errfile != "" && success < total {
+		err := ioutil.WriteFile(*errfile, []byte(errstr), os.ModePerm)
+		if err != nil {
+			lg.Errorf("Unable to write results file %s: %s", *errfile, err.Error())
+		}
+	}
+	lg.Infof("%d out of %d queries succeeded (%0.02f%%)", success, total, (float64(success) / float64(total))*100)
+	wg.Wait()
+}

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -6,8 +6,6 @@ import (
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"github.com/miekg/dns"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -19,6 +17,9 @@ import (
 	"sync"
 	"tenta-dns/log"
 	"time"
+
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -160,7 +161,7 @@ func (w *worker) doWork(id uint) {
 			c.SingleInflight = true
 			c.DialTimeout = time.Second
 			c.WriteTimeout = time.Second * 3
-			c.ReadTimeout = time.Second * 10
+			c.ReadTimeout = time.Second * 30
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -231,7 +231,7 @@ func testRecords(r *csv.Reader, num uint, lg *logrus.Entry) {
 		case r := <-rc:
 			results[r.name] = r
 			break
-		case <-time.After(time.Second * 15):
+		case <-time.After(time.Second * 60):
 			run = false
 			break
 		}

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -159,9 +159,10 @@ func (w *worker) doWork(id uint) {
 				c.Net = "tcp-tls"
 			}
 			c.SingleInflight = true
-			c.DialTimeout = time.Second
-			c.WriteTimeout = time.Second * 3
-			c.ReadTimeout = time.Second * 30
+			// c.DialTimeout = time.Second * 10
+			// c.WriteTimeout = time.Second * 10
+			// c.ReadTimeout = time.Second * 30
+			c.Timeout = time.Second * 300
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -151,7 +151,7 @@ func (w *worker) doWork(id uint) {
 			c.SingleInflight = true
 			c.DialTimeout = time.Second
 			c.WriteTimeout = time.Second * 3
-			c.ReadTimeout = time.Second * 5
+			c.ReadTimeout = time.Second * 10
 			in, _, err := c.Exchange(m, net.JoinHostPort(*ip, strconv.Itoa(int(*port))))
 			s := false
 			msg := ""

--- a/src/tenta-dns/stresser/stresser.go
+++ b/src/tenta-dns/stresser/stresser.go
@@ -230,7 +230,7 @@ func testRecords(r *csv.Reader, num uint, lg *logrus.Entry) {
 		case r := <-rc:
 			results[r.name] = r
 			break
-		case <-time.After(time.Second * 3):
+		case <-time.After(time.Second * 15):
 			run = false
 			break
 		}

--- a/src/tenta-dns/tenta-dns.go
+++ b/src/tenta-dns/tenta-dns.go
@@ -43,10 +43,14 @@ var (
 	quiet          = flag.Bool("quiet", false, "Don't produce any output to the terminal")
 	verbose        = flag.Bool("verbose", false, "Produce lots of output to the terminal (overrides the -quiet flag)")
 	systemd        = flag.Bool("systemd", false, "Assume running under systemd and send control notifications. NOTE: Behavior is undefined if using this flag without systemd")
+	printver       = flag.Bool("version", false, "Print the version and exit")
 )
 
+var version string
+
 func usage() {
-	fmt.Println("Tenta DNS")
+	fmt.Printf("Tenta DNS %s", version)
+	fmt.Println("")
 	fmt.Println("Full featured DNS server with DNSSEC and DNS-over-TLS")
 	fmt.Println("Options:")
 	flag.PrintDefaults()
@@ -56,6 +60,11 @@ func main() {
 	log.SetLogLevel(logrus.InfoLevel)
 	flag.Usage = usage
 	flag.Parse()
+
+	if *printver {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	if *quiet {
 		log.SetLogLevel(logrus.FatalLevel)


### PR DESCRIPTION
Add the ability to cycle through public IPs when making connections to upstream resolvers, to avoid IP based lockouts. Added a stress testing tool.