### PR TITLE
Create Releases using GoReleaser support #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /responses.db/
 /geo.db/
 .idea/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+project_name: tenta-dns
+release:
+  github:
+    owner: tenta-browser
+    name: tenta-dns
+  name_template: '{{.Tag}}'
+brew:
+  commit_author:
+    name: tenta-browser
+    email: info@tenta.com
+  install: bin.install "tenta-dns"
+builds:
+- goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - "386"
+  main: tenta-dns.go
+  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  binary: tenta-dns
+archive:
+  format: tar.gz
+  name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+    .Arm }}{{ end }}'
+  files:
+  - LICENSE*
+  - README*
+  - changelog*
+  - CHANGELOG*
+fpm:
+  bindir: /usr/local/bin
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+dist: dist
+sign:
+  cmd: gpg
+  args:
+  - --output
+  - $signature
+  - --detach-sig
+  - $artifact
+  signature: ${artifact}.sig
+  artifacts: none
+dockers:
+  - image: tenta/tenta-dns
+    latest: true
+    tag_template: '{{ .Tag }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine
+
+RUN mkdir -p /etc/nsnitch/conf.d && \
+    mkdir -p /etc/nsnitch/certs && \
+    mkdir -p /etc/nsnitch/geo.db
+
+
+ADD $GOPATH/github.com/tenta-browser/tenta-dns/etc/words.txt     /etc/nsnitch/words.txt
+ADD $GOPATH/github.com/tenta-browser/tenta-dns/etc/config.toml   /etc/nsnitch/config.toml
+
+COPY tenta-dns /app/
+
+CMD ["/app/tenta-dns", "-config", "/etc/nsnitch/config.toml"]


### PR DESCRIPTION
Added [GoReleaser](https://github.com/goreleaser/goreleaser) support.  For docker image, there is an [issue](https://github.com/moby/moby/issues/2745). Docker doesn't allow to copy file from parent folder. 
