### PR TITLE
Updated link to The English Open Word List to fix 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We rely on lots of excellent open source libraries, including [miekg/dns](https:
 [osrg/gobgp](https://github.com/osrg/gobgp), as well as many others. For a complete list of our dependencies and required notification,
 please take a look at [NOTICES.md](NOTICES.md)
 
-The `words.txt` file used for random names in NSnitch is from [dreamsteep.com](http://dreamsteep.com/projects/the-english-open-word-list.html).
+The `words.txt` file used for random names in NSnitch is from [dreamsteep.com](http://diginoodles.com/The_English_Open_Word_List_%28EOWL%29).
 
 License
 =======


### PR DESCRIPTION
Changed http://dreamsteep.com/projects/the-english-open-word-list.html that was linking to a 404 not found page to  http://diginoodles.com/The_English_Open_Word_List_%28EOWL%29