### PR TITLE
Add support for RFC6844 and RFC5785

### DIFF
--- a/etc/conf.d/nsnitch.toml
+++ b/etc/conf.d/nsnitch.toml
@@ -21,16 +21,17 @@ timezone="UTC"
 redirectmode="wordlist"
 wordlistpath="/etc/nsnitch/words.txt"
 # Provide values for "/.well-known" responses
-[[wellknowns]]
-  [wellknown]
-  # The path under, "/.well-known/", this expands to "/.well-known/pki-validation/ABC123.txt"
-  path="pki-validation/ABC123.txt"
-  # The literal body to serve, optionally Base64 encoded
-  body="ABC123 certificate.authority.net xzy987"
-  # Whether the body is base64 encoded
-  base64=false
-  # The mime type to use when serving this response
-  mimetype="text/plain"
+
+[wellknowns]
+    [wellknowns.ABC123]
+    # The path under, "/.well-known/", this expands to "/.well-known/pki-validation/ABC123.txt"
+    path="pki-validation/ABC123.txt"
+    # The literal body to serve, optionally Base64 encoded
+    body="ABC123 certificate.authority.net xzy987"
+    # Whether the body is base64 encoded
+    base64=false
+    # The mime type to use when serving this response
+    mimetype="text/plain"
 
 # The list of domains to bind to
 [domains]

--- a/etc/conf.d/nsnitch.toml
+++ b/etc/conf.d/nsnitch.toml
@@ -33,6 +33,9 @@ wordlistpath="/etc/nsnitch/words.txt"
     certfile="/etc/nsnitch/certs/star_nstoro_com.chained.crt"
     keyfile="/etc/nsnitch/certs/star_nstoro_com.key"
     nameservers=["1.2.3.4", "5.6.7.8"]
+    caaiodef="reports@example.net"
+    caaissuewild=["letsencrypt.com"]
+    # caaissue is also available, but not very useful in this scenario
 
 # Domains to enable CORS for
 corsdomains=["tenta.io", "tenta.com"]

--- a/etc/conf.d/nsnitch.toml
+++ b/etc/conf.d/nsnitch.toml
@@ -20,12 +20,16 @@ timezone="UTC"
 # wordlist mode generates plausible subdomains from wordlist
 redirectmode="wordlist"
 wordlistpath="/etc/nsnitch/words.txt"
-
+# Provide values for "/.well-known" responses
 [[wellknowns]]
   [wellknown]
+  # The path under, "/.well-known/", this expands to "/.well-known/pki-validation/ABC123.txt"
   path="pki-validation/ABC123.txt"
+  # The literal body to serve, optionally Base64 encoded
   body="ABC123 certificate.authority.net xzy987"
+  # Whether the body is base64 encoded
   base64=false
+  # The mime type to use when serving this response
   mimetype="text/plain"
 
 # The list of domains to bind to

--- a/etc/conf.d/nsnitch.toml
+++ b/etc/conf.d/nsnitch.toml
@@ -33,8 +33,8 @@ wordlistpath="/etc/nsnitch/words.txt"
     certfile="/etc/nsnitch/certs/star_nstoro_com.chained.crt"
     keyfile="/etc/nsnitch/certs/star_nstoro_com.key"
     nameservers=["1.2.3.4", "5.6.7.8"]
-    caaiodef="reports@example.net"
-    caaissuewild=["letsencrypt.com"]
+    caaiodef=["reports@example.net"]
+    caaiwild=["letsencrypt.com"]
     # caaissue is also available, but not very useful in this scenario
 
 # Domains to enable CORS for

--- a/etc/conf.d/nsnitch.toml
+++ b/etc/conf.d/nsnitch.toml
@@ -21,8 +21,15 @@ timezone="UTC"
 redirectmode="wordlist"
 wordlistpath="/etc/nsnitch/words.txt"
 
+[[wellknowns]]
+  [wellknown]
+  path="pki-validation/ABC123.txt"
+  body="ABC123 certificate.authority.net xzy987"
+  base64=false
+  mimetype="text/plain"
+
 # The list of domains to bind to
-[domaains]
+[domains]
     [domains.domain1]
     hostname="example.org"
     ipv4="127.0.0.2"

--- a/responder/http-handlers/http_handler_wellknown.go
+++ b/responder/http-handlers/http_handler_wellknown.go
@@ -1,0 +1,20 @@
+package http_handlers
+
+import (
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"github.com/tenta-browser/tenta-dns/runtime"
+	"fmt"
+)
+
+func HandleHTTPWellKnown(cfg runtime.NSnitchConfig, rt *runtime.Runtime, lgr *logrus.Entry, path string, body []byte, mime string) httpHandler {
+	bodylen := fmt.Sprintf("%d", len(body))
+	return wrapExtendedHttpHandler(rt, lgr, "well-known", func(w http.ResponseWriter, r *http.Request, lg *logrus.Entry) {
+		lgr.Debugf("Serving well-known %s", path)
+		w.Header().Set("Content-Type", mime)
+		w.Header().Set("Content-Length", bodylen)
+		extraHeaders(cfg, w, r)
+		w.WriteHeader(200)
+		w.Write(body)
+	})
+}

--- a/responder/snitch_dns.go
+++ b/responder/snitch_dns.go
@@ -295,42 +295,32 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 			//m.Extra = append(m.Extra, t)
 		}
 		writeCAA := func() {
-			if len(d.CAAIodef) > 0 {
-				iodef := &dns.CAA{
-					Tag: "iodef",
-					Value: d.CAAIodef,
+			makeCaa := func(tag, value string) *dns.CAA {
+				return &dns.CAA{
+					Hdr: dns.RR_Header{Name: queried, Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0},
+					Tag: tag,
+					Value: value,
 				}
-				m.Answer = append(m.Answer, iodef)
+			}
+
+			if len(d.CAAIodef) > 0 {
+				for _, iname := range d.CAAIodef {
+					m.Answer = append(m.Answer, makeCaa("iodef", iname))
+				}
 			}
 			if len(d.CAAIssue) > 0 {
 				for _, iname := range d.CAAIssue {
-					issue := &dns.CAA{
-						Tag: "issue",
-						Value: iname,
-					}
-					m.Answer = append(m.Answer, issue)
+					m.Answer = append(m.Answer, makeCaa("issue", iname))
 				}
 			} else {
-				issue := &dns.CAA{
-					Tag: "issue",
-					Value: ";",
-				}
-				m.Answer = append(m.Answer, issue)
+				m.Answer = append(m.Answer, makeCaa("issue", ";"))
 			}
-			if len(d.CAAIssueWild) > 0 {
-				for _, iname := range d.CAAIssue {
-					issue := &dns.CAA{
-						Tag: "issuewild",
-						Value: iname,
-					}
-					m.Answer = append(m.Answer, issue)
+			if len(d.CAAIWild) > 0 {
+				for _, iname := range d.CAAIWild {
+					m.Answer = append(m.Answer, makeCaa("issuewild", iname))
 				}
 			} else {
-				issue := &dns.CAA{
-					Tag: "issuewild",
-					Value: ";",
-				}
-				m.Answer = append(m.Answer, issue)
+				m.Answer = append(m.Answer, makeCaa("issuewild", ";"))
 			}
 			skipdb = true
 		}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
+	"encoding/base64"
 )
 
 const PORT_UNSET = 0
@@ -74,6 +75,7 @@ type NSnitchConfig struct {
 	WordListPath string
 	CorsDomains  []string
 	Blacklists   []string
+	WellKnowns	 []WellKnown
 	BlacklistTTL int64
 }
 
@@ -117,6 +119,13 @@ type NodeConfig struct {
 	AS         uint
 	Org        string
 	TimeZone   string
+}
+
+type WellKnown struct {
+	Path		string
+	Body		string
+	Base64		bool
+	MimeType	string
 }
 
 type ConfigHolder struct {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -104,6 +104,9 @@ type ServerDomain struct {
 	DnsUdpPort  int
 	DnsTcpPort  int
 	DnsTlsPort  int
+	CAAIodef	 string
+	CAAIssue	 []string
+	CAAIssueWild []string
 }
 
 type NodeConfig struct {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -104,9 +104,9 @@ type ServerDomain struct {
 	DnsUdpPort  int
 	DnsTcpPort  int
 	DnsTlsPort  int
-	CAAIodef	 string
-	CAAIssue	 []string
-	CAAIssueWild []string
+	CAAIodef	[]string
+	CAAIssue	[]string
+	CAAIWild	[]string
 }
 
 type NodeConfig struct {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
-	"encoding/base64"
 )
 
 const PORT_UNSET = 0

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -74,7 +74,7 @@ type NSnitchConfig struct {
 	WordListPath string
 	CorsDomains  []string
 	Blacklists   []string
-	WellKnowns	 []WellKnown
+	WellKnowns	 map[string]*WellKnown
 	BlacklistTTL int64
 }
 


### PR DESCRIPTION
Adds support to NSNitch for serving `/.well-known` files, necessary for some certificate issuers and a variety of other uses. Also adds support for serving CAA records from NSnitch.