### PR TITLE
Fixed occasional error on report API

### DIFF
--- a/responder/randomizer/randomizer.go
+++ b/responder/randomizer/randomizer.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"unicode"
+	"strings"
 
 	"github.com/tenta-browser/tenta-dns/common"
 	"github.com/tenta-browser/tenta-dns/log"
@@ -83,7 +83,7 @@ func NewWordListRandomizer(cfg runtime.NSnitchConfig) Randomizer {
 		}
 		buffer.Write(part)
 		if !prefix {
-			rnd.wordlist = append(rnd.wordlist, buffer.String())
+			rnd.wordlist = append(rnd.wordlist, strings.ToLower(buffer.String()))
 			buffer.Reset()
 		}
 	}
@@ -118,17 +118,17 @@ func (rnd WordRandomizer) Rand() (string, error) {
 			}
 		}
 		word := rnd.wordlist[common.RandInt(rnd.wordlistlen)]
-		switch common.RandInt(4) {
-		case 0, 1, 2:
-			for i, v := range word {
-				word = string(unicode.ToUpper(v)) + word[i+1:]
-				break
-			}
-			break
-		default:
-			// Do nothing
-			break
-		}
+		// switch common.RandInt(4) {
+		// case 0, 1, 2:
+		// 	for i, v := range word {
+		// 		word = string(unicode.ToUpper(v)) + word[i+1:]
+		// 		break
+		// 	}
+		// 	break
+		// default:
+		// 	// Do nothing
+		// 	break
+		// }
 		buffer.WriteString(word)
 	}
 	return buffer.String(), nil

--- a/responder/snitch_dns.go
+++ b/responder/snitch_dns.go
@@ -187,12 +187,12 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 		if v4 {
 			serverIp = &dns.A{
 				Hdr: dns.RR_Header{Name: queried, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0},
-				A:   net.ParseIP(d.IPv4),
+				A:   net.ParseIP(cfg.DnsReplyv4),
 			}
 		} else {
 			serverIp = &dns.AAAA{
 				Hdr:  dns.RR_Header{Name: queried, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
-				AAAA: net.ParseIP(d.IPv6),
+				AAAA: net.ParseIP(cfg.DnsReplyv6),
 			}
 		}
 

--- a/responder/snitch_dns.go
+++ b/responder/snitch_dns.go
@@ -109,7 +109,7 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 	return func(w dns.ResponseWriter, r *dns.Msg) {
 		var (
 			v4       bool
-			serverIp dns.RR
+			serverIp []dns.RR
 			//str       string
 			a       net.IP
 			queried string
@@ -185,14 +185,18 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 		}
 
 		if v4 {
-			serverIp = &dns.A{
-				Hdr: dns.RR_Header{Name: queried, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0},
-				A:   net.ParseIP(cfg.DnsReplyv4),
+			for _, confA := range cfg.DnsReplyv4 {
+				serverIp = append(serverIp, &dns.A{
+					Hdr: dns.RR_Header{Name: queried, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 0},
+					A:   net.ParseIP(confA),
+				})
 			}
 		} else {
-			serverIp = &dns.AAAA{
-				Hdr:  dns.RR_Header{Name: queried, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
-				AAAA: net.ParseIP(cfg.DnsReplyv6),
+			for _, confAAAA := range cfg.DnsReplyv6 {
+				serverIp = append(serverIp, &dns.AAAA{
+					Hdr:  dns.RR_Header{Name: queried, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
+					AAAA: net.ParseIP(confAAAA),
+				})
 			}
 		}
 
@@ -291,14 +295,14 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 			skipdb = true
 		}
 		writeA := func() {
-			m.Answer = append(m.Answer, serverIp)
+			m.Answer = append(m.Answer, serverIp...)
 			//m.Extra = append(m.Extra, t)
 		}
 		writeCAA := func() {
 			makeCaa := func(tag, value string) *dns.CAA {
 				return &dns.CAA{
-					Hdr: dns.RR_Header{Name: queried, Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0},
-					Tag: tag,
+					Hdr:   dns.RR_Header{Name: queried, Rrtype: dns.TypeCAA, Class: dns.ClassINET, Ttl: 0},
+					Tag:   tag,
 					Value: value,
 				}
 			}
@@ -351,7 +355,7 @@ func handleSnitch(cfg runtime.NSnitchConfig, rt *runtime.Runtime, d *runtime.Ser
 		case dns.TypeCAA:
 			rt.Stats.Count("dns:queries:internal:caa")
 			writeCAA()
-			break;
+			break
 		default:
 			break
 		}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -76,6 +76,8 @@ type NSnitchConfig struct {
 	Blacklists   []string
 	WellKnowns	 map[string]*WellKnown
 	BlacklistTTL int64
+	DnsReplyv4 string
+	DnsReplyv6 string
 }
 
 type RecursorConfig struct {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -74,10 +74,10 @@ type NSnitchConfig struct {
 	WordListPath string
 	CorsDomains  []string
 	Blacklists   []string
-	WellKnowns	 map[string]*WellKnown
+	WellKnowns   map[string]*WellKnown
 	BlacklistTTL int64
-	DnsReplyv4 string
-	DnsReplyv6 string
+	DnsReplyv4   []string
+	DnsReplyv6   []string
 }
 
 type RecursorConfig struct {
@@ -107,9 +107,9 @@ type ServerDomain struct {
 	DnsUdpPort  int
 	DnsTcpPort  int
 	DnsTlsPort  int
-	CAAIodef	[]string
-	CAAIssue	[]string
-	CAAIWild	[]string
+	CAAIodef    []string
+	CAAIssue    []string
+	CAAIWild    []string
 }
 
 type NodeConfig struct {
@@ -126,10 +126,10 @@ type NodeConfig struct {
 }
 
 type WellKnown struct {
-	Path		string
-	Body		string
-	Base64		bool
-	MimeType	string
+	Path     string
+	Body     string
+	Base64   bool
+	MimeType string
 }
 
 type ConfigHolder struct {


### PR DESCRIPTION
By returning unicast IPs from the authoritative daemon, thus forcing the client to fetch the report from the same running instance